### PR TITLE
Remove some IDE warnings

### DIFF
--- a/solutions/custom-idp/src/idp_handler/app.py
+++ b/solutions/custom-idp/src/idp_handler/app.py
@@ -1,13 +1,11 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied.
 
-import datetime
 import importlib
 import ipaddress
 import json
 import logging
 import os
-import random
 
 import boto3
 from aws_xray_sdk.core import patch_all, xray_recorder
@@ -28,7 +26,7 @@ IDENTITY_PROVIDERS_TABLE = boto3.resource("dynamodb").Table(IDENTITY_PROVIDERS_T
 
 
 class IdpHandlerException(Exception):
-    "Used to raise handler exceptions"
+    """Used to raise handler exceptions"""
     pass
 
 
@@ -166,7 +164,7 @@ def lambda_handler(event, context):
         )
         response_data["Role"] = identity_provider_record["config"]["Role"]
     else:
-        logger.warn(
+        logger.warning(
             f"Role arn not found in user record for {input_username} or identity provider record {identity_provider}. It may still be provided by identity provider response."
         )
 
@@ -213,7 +211,7 @@ def lambda_handler(event, context):
         ]
         response_data["HomeDirectoryType"] = "PATH"
     else:
-        logger.warn(
+        logger.warning(
             f"HomeDirectory and HomeDirectoryDetails in user record for {input_username} or identity provider record {identity_provider}"
         )
 

--- a/solutions/custom-idp/src/idp_handler/idp_modules/argon2.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/argon2.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.DEBUG if os.environ.get("LOGLEVEL", "DEBUG") else loggin
 
 
 class Argon2IdpModuleError(util.IdpModuleError):
-    "Used to raise module-specific exceptions"
+    """Used to raise module-specific exceptions"""
     pass
 
 
@@ -22,7 +22,7 @@ def handle_auth(
 ):
     logger.debug(f"User record: {user_record}")  
 
-    if authn_method == util.AuthenticationMethod.PUBLIC_KEY:
+    if authn_method != util.AuthenticationMethod.PASSWORD:
         raise Argon2IdpModuleError(
             "Password not specified, this provider does not support public key auth."
     )

--- a/solutions/custom-idp/src/idp_handler/idp_modules/ldap.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/ldap.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.DEBUG if os.environ.get("LOGLEVEL", "DEBUG") else loggin
 
 
 class LdapIdpModuleError(util.IdpModuleError):
-    "Used to raise module-specific exceptions"
+    """Used to raise module-specific exceptions"""
     pass
 
 
@@ -23,23 +23,23 @@ def handle_auth(
 ):
     logger.debug(f"User record: {user_record}")
 
-    if authn_method == util.AuthenticationMethod.PUBLIC_KEY:
+    if authn_method != util.AuthenticationMethod.PASSWORD:
         raise LdapIdpModuleError(
             "Password not specified, this provider does not support public key auth."
         )
 
-    user_record_config = user_record["config"]
-    ldap_host = identity_provider_record["config"]["server"]
-    ldap_port = int(identity_provider_record["config"].get("port", 636))
-    ldap_ssl = identity_provider_record["config"].get("ssl", True)
-    ldap_ssl_verify = identity_provider_record["config"].get("ssl_verify", True)
-    ldap_attributes = identity_provider_record["config"].get("attributes", {})
-    ldap_search_base = identity_provider_record["config"]["search_base"]
-    ldap_ignore_missing_attributes = identity_provider_record["config"].get(
+    identity_provider_config = identity_provider_record["config"]
+    ldap_host = identity_provider_config["server"]
+    ldap_port = int(identity_provider_config.get("port", 636))
+    ldap_ssl = identity_provider_config.get("ssl", True)
+    ldap_ssl_verify = identity_provider_config.get("ssl_verify", True)
+    ldap_attributes = identity_provider_config.get("attributes", {})
+    ldap_search_base = identity_provider_config["search_base"]
+    ldap_ignore_missing_attributes = identity_provider_config.get(
         "ignore_missing_attributes", False
     )
-    if "domain" in identity_provider_record["config"]:
-        ldap_domain = identity_provider_record["config"]["domain"]
+    if "domain" in identity_provider_config:
+        ldap_domain = identity_provider_config["domain"]
         domain_username = f"{ldap_domain}\{parsed_username}"
     else:
         domain_username = parsed_username
@@ -123,7 +123,7 @@ def handle_auth(
             )
             response_data["Role"] = ldap_resolved_attributes["Role"]
         elif ldap_ignore_missing_attributes:
-            logger.warn(
+            logger.warning(
                 f"LDAP attribute {ldap_attributes['Role']} for 'Role' was empty of missing. Skipping."
             )
         else:
@@ -136,7 +136,7 @@ def handle_auth(
             logger.info("Applying Policy from LDAP Attributes")
             response_data["Policy"] = ldap_resolved_attributes["Policy"]
         elif ldap_ignore_missing_attributes:
-            logger.warn(
+            logger.warning(
                 f"LDAP attribute {ldap_attributes['Policy']} for 'Policy' was empty of missing. Skipping."
             )
         else:
@@ -156,7 +156,7 @@ def handle_auth(
             response_data["PosixProfile"]["Uid"] = ldap_resolved_attributes["Uid"]
             response_data["PosixProfile"]["Gid"] = ldap_resolved_attributes["Gid"]
         elif ldap_ignore_missing_attributes:
-            logger.warn(
+            logger.warning(
                 f"LDAP attributes {ldap_attributes['Uid']} for 'Uid' and/or {ldap_attributes['Gid']} for 'Gid' were empty of missing. Skipping."
             )
         else:

--- a/solutions/custom-idp/src/idp_handler/idp_modules/okta.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/okta.py
@@ -1,11 +1,8 @@
-import json
 import logging
 import os
-import re
-import urllib.parse
 
 import urllib3
-from aws_xray_sdk.core import patch_all, xray_recorder
+from aws_xray_sdk.core import patch_all
 from idp_modules import util
 
 patch_all()
@@ -18,7 +15,7 @@ http = urllib3.PoolManager()
 
 
 class OktaIdpModuleError(util.IdpModuleError):
-    "Used to raise module-specific exceptions"
+    """Used to raise module-specific exceptions"""
     pass
 
 
@@ -64,7 +61,7 @@ def okta_authenticate(url, username, password, mfa_token=None):
             )
             return primary_response_json
     else:
-        logger.warn(
+        logger.warning(
             f"Authentication status was not SUCCESS for user {username}. Status returned: {primary_response_status}"
         )
         if primary_response_status == "MFA_REQUIRED":
@@ -102,13 +99,13 @@ def okta_authenticate(url, username, password, mfa_token=None):
         )
 
         if mfa_response.status != 200:
-            logger.warn(
+            logger.warning(
                 f"MFA failed for factor Id {mfa_factor.get('id', '')}; Type {mfa_factor.get('factorType', '')}; Provider {mfa_factor.get('provider', '')}"
             )
         else:
             mfa_response_status = primary_response_json.get("status", "<none>")
             if mfa_response_status == "SUCCESS":
-                logger.warn(
+                logger.warning(
                     f"MFA authentication status for was not SUCCESS for user {username}; factor Id {mfa_factor.get('id', '')}; Type {mfa_factor.get('factorType', '')}; Provider {mfa_factor.get('provider', '')}. Status returned: {mfa_response_status}. "
                 )
             else:
@@ -330,7 +327,7 @@ def handle_auth(
             )
             response_data["Role"] = okta_resolved_attributes["Role"]
         elif okta_ignore_missing_attributes:
-            logger.warn(
+            logger.warning(
                 f"Okta user profile attribute '{okta_attributes['Role']}' for 'Role' was empty of missing. Skipping."
             )
         else:
@@ -343,7 +340,7 @@ def handle_auth(
             logger.info("Applying Policy from Okta user profile attributes")
             response_data["Policy"] = okta_resolved_attributes["Policy"]
         elif okta_ignore_missing_attributes:
-            logger.warn(
+            logger.warning(
                 f"Okta user profile attribute '{okta_attributes['Policy']}' for 'Policy' was empty of missing. Skipping."
             )
         else:
@@ -363,7 +360,7 @@ def handle_auth(
             response_data["PosixProfile"]["Uid"] = okta_resolved_attributes["Uid"]
             response_data["PosixProfile"]["Gid"] = okta_resolved_attributes["Gid"]
         elif okta_ignore_missing_attributes:
-            logger.warn(
+            logger.warning(
                 f"Okta user profile attributes '{okta_attributes['Uid']}' for 'Uid' and/or '{okta_attributes['Gid']}' for 'Gid' were empty of missing. Skipping."
             )
         else:

--- a/solutions/custom-idp/src/idp_handler/idp_modules/public_key.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/public_key.py
@@ -11,7 +11,7 @@ logger.setLevel(logging.DEBUG if os.environ.get("LOGLEVEL", "DEBUG") else loggin
 
 
 class PublicKeyIdpModuleError(util.IdpModuleError):
-    "Used to raise module-specific exceptions"
+    """Used to raise module-specific exceptions"""
     pass
 
 

--- a/solutions/custom-idp/src/idp_handler/idp_modules/secrets_manager.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/secrets_manager.py
@@ -10,7 +10,7 @@ patch_all()
 
 
 class SecretsManagerIdpModuleError(util.IdpModuleError):
-    "Used to raise module-specific exceptions"
+    """Used to raise module-specific exceptions"""
     pass
 
 

--- a/solutions/custom-idp/src/idp_handler/idp_modules/util.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/util.py
@@ -17,8 +17,9 @@ boto3_config = Config(retries={"max_attempts": 10, "mode": "standard"})
 
 
 class IdpModuleError(Exception):
-    "Used to raise IdP module exceptions"
+    """Used to raise IdP module exceptions"""
     pass
+
 
 class AuthenticationMethod(Enum):
     PASSWORD = 1
@@ -26,13 +27,13 @@ class AuthenticationMethod(Enum):
 
 
 @xray_recorder.capture()
-def get_secret(id):
+def get_secret(secret_id):
     client = boto3.session.Session().client(
         service_name="secretsmanager", config=boto3_config
     )
 
     try:
-        resp = client.get_secret_value(SecretId=id)
+        resp = client.get_secret_value(SecretId=secret_id)
         # Decrypts secret using the associated KMS CMK.
         # Depending on whether the secret is a string or binary, one of these fields will be populated.
         if "SecretString" in resp:


### PR DESCRIPTION
Some formatting fixes inspired by my IDE: 

* Replace the deprecated `logger.warn()` with `logger.warning()`
* Add """ for exception comment
* Remove some now unused imports
* `id` variable rename to avoid overwriting an existing variable

In case we end up with more than one `AuthenticationMethod` in the future, changed `if authn_method == util.AuthenticationMethod.PUBLIC_KEY` with `if authn_method != util.AuthenticationMethod.PASSWORD` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
