### PR TITLE
Add new user automatically to the Microsoft AD as part of the deployment

### DIFF
--- a/solutions/custom-idp/custom-idp.yaml
+++ b/solutions/custom-idp/custom-idp.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: >
+Description: 'This template deploys custom IdP including VPC, Subnets, Security Groups, IdP Handler Lambda and API Gateway (if selected)'
 
 Parameters:
   CreateVPC:

--- a/solutions/custom-idp/custom-idp.yaml
+++ b/solutions/custom-idp/custom-idp.yaml
@@ -630,6 +630,9 @@ Resources:
             
 
 Outputs:
+  IdpHandlerLayer:
+    Description: IDP Handler Layer
+    Value: !Ref IdpHandlerLayer
   IdpHandlerFunction:
     Description: IDP Handler Arn
     Value: !GetAtt IdpHandlerFunction.Arn

--- a/solutions/custom-idp/examples/activedirectory/create_ad_user.yaml
+++ b/solutions/custom-idp/examples/activedirectory/create_ad_user.yaml
@@ -36,7 +36,6 @@ Parameters:
   NewADUser:
     Description: New AD User
     Type: String
-    NoEcho: true
   NewADUserPassword:
     Description: New AD User Password
     Type: String
@@ -100,6 +99,7 @@ Resources:
       CodeUri: src/add_aduser_handler/
       Handler: app.lambda_handler
       Runtime: python3.11
+      Timeout: 30
       FunctionName: !Sub ${AWS::StackName}-add_ad_user
       Layers:
         - !Ref IdpHandlerLayerArn

--- a/solutions/custom-idp/examples/activedirectory/create_ad_user.yaml
+++ b/solutions/custom-idp/examples/activedirectory/create_ad_user.yaml
@@ -1,0 +1,124 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+
+Parameters:
+  IdpHandlerLayerArn:
+    Description: Arn for the IdpHandlerLayer
+    Type: String
+  SecurityGroupsList:
+    Description: A list of SecurityGroup Ids    
+    Type: String
+  SubnetList:
+    Description: A list of Subnet Ids
+    Type: String
+  ADServerDNS:
+    Description: AD Server DNS
+    Type: String
+  ADServerPort:
+    Description: AD Server Port
+    Type: String
+  ADDomainUser:
+    Description: AD DomainUser
+    Type: String
+    NoEcho: true
+  ADDomainUserPassword:
+    Description: AD DomainUser Password
+    Type: String
+    NoEcho: true
+  ADSearchBase:
+    Description: AD User Search Base
+    Type: String
+  ADSSL:
+    Description: Whether to use SSL
+    Type: String
+    Default: 'false' 
+  NewADUser:
+    Description: New AD User
+    Type: String
+    NoEcho: true
+  
+Conditions:
+  SSL: !Equals [!Ref ADSSL, 'true']
+
+
+Resources:
+  ADDomainUserSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: AD Domain User Secret
+      Name: !Sub ${AWS::StackName}-ADDomainUser
+      SecretString: !Ref ADDomainUser
+  ADDomainUserPasswordSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: AD Domain User Password Secret
+      Name: !Sub ${AWS::StackName}-ADDomainUserPassword
+      SecretString: !Ref ADDomainUserPassword
+  ADNewUserSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: AD New User Secret
+      Name: !Sub ${AWS::StackName}-NewADUser
+      SecretString: !Ref NewADUser
+  AddADUserLambda:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken:
+        !Sub
+        - arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${LambdaFunctionName}
+        - { LambdaFunctionName: !Ref CreateADUserHandlerFunction }
+      Region: !Sub '${AWS::Region}'
+  CreateADHandlerFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CreateADUserHandlerFunction
+      Action: lambda:InvokeFunction
+      Principal: "lambda.amazonaws.com"
+      SourceAccount: !Ref AWS::AccountId
+ 
+  CreateADUserHandlerFunction:
+    Type: AWS::Serverless::Function
+    DependsOn:
+      - ADDomainUserSecret
+      - ADDomainUserPasswordSecret
+      - ADNewUserSecret
+    Properties:
+      CodeUri: src/add_aduser_handler/
+      Handler: app.lambda_handler
+      Runtime: python3.11
+      FunctionName: !Sub ${AWS::StackName}-add_ad_user
+      Layers:
+        - !Ref IdpHandlerLayerArn
+      Environment:
+        Variables:
+          AWS_XRAY_TRACING_NAME: !Sub ${AWS::StackName}
+          ADServerDNS: !Ref ADServerDNS
+          ADServerPort: !Ref ADServerPort
+          ADDomainUser: !Sub ${AWS::StackName}-ADDomainUser
+          ADDomainUserPassword: !Sub ${AWS::StackName}-ADDomainUserPassword
+          ADNewUser: !Sub ${AWS::StackName}-NewADUser
+          ADSSL: !Ref ADSSL
+          ADSearchBase: !Ref ADSearchBase
+          Region: !Sub ${AWS::Region}
+      VpcConfig:
+        SubnetIds: !Split
+              - ","
+              - !Ref SubnetList
+        SecurityGroupIds: !Split
+              - ","
+              - !Ref SecurityGroupsList
+      Architectures:
+      - x86_64
+      Policies:
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - 'ec2:DescribeImages'
+              Resource: '*'
+            - Effect: Allow
+              Action: 
+                - secretsmanager:GetSecretValue
+              Resource: 
+                - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*

--- a/solutions/custom-idp/examples/activedirectory/create_ad_user.yaml
+++ b/solutions/custom-idp/examples/activedirectory/create_ad_user.yaml
@@ -37,7 +37,14 @@ Parameters:
     Description: New AD User
     Type: String
     NoEcho: true
-  
+  NewADUserPassword:
+    Description: New AD User Password
+    Type: String
+    NoEcho: true
+  DirectoryId:
+    Description: ActiveDirectory ID
+    Type: String
+      
 Conditions:
   SSL: !Equals [!Ref ADSSL, 'true']
 
@@ -61,6 +68,12 @@ Resources:
       Description: AD New User Secret
       Name: !Sub ${AWS::StackName}-NewADUser
       SecretString: !Ref NewADUser
+  NewADUserPasswordSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: AD New User Secret
+      Name: !Sub ${AWS::StackName}-NewADUserPassword
+      SecretString: !Ref NewADUserPassword
   AddADUserLambda:
     Type: AWS::CloudFormation::CustomResource
     Properties:
@@ -68,7 +81,6 @@ Resources:
         !Sub
         - arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${LambdaFunctionName}
         - { LambdaFunctionName: !Ref CreateADUserHandlerFunction }
-      Region: !Sub '${AWS::Region}'
   CreateADHandlerFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -83,6 +95,7 @@ Resources:
       - ADDomainUserSecret
       - ADDomainUserPasswordSecret
       - ADNewUserSecret
+      - NewADUserPasswordSecret
     Properties:
       CodeUri: src/add_aduser_handler/
       Handler: app.lambda_handler
@@ -98,9 +111,11 @@ Resources:
           ADDomainUser: !Sub ${AWS::StackName}-ADDomainUser
           ADDomainUserPassword: !Sub ${AWS::StackName}-ADDomainUserPassword
           ADNewUser: !Sub ${AWS::StackName}-NewADUser
+          NewADUserPassword: !Sub ${AWS::StackName}-NewADUserPassword
           ADSSL: !Ref ADSSL
           ADSearchBase: !Ref ADSearchBase
           Region: !Sub ${AWS::Region}
+          DirectoryId: !Ref DirectoryId
       VpcConfig:
         SubnetIds: !Split
               - ","
@@ -122,3 +137,9 @@ Resources:
                 - secretsmanager:GetSecretValue
               Resource: 
                 - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*
+            - Effect: Allow
+              Action:
+                - ds:ResetUserPassword
+              Resource:
+                - !Sub arn:${AWS::Partition}:ds:${AWS::Region}:${AWS::AccountId}:directory/${DirectoryId}
+

--- a/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
+++ b/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
@@ -16,7 +16,6 @@ Parameters:
     Type: String
     MinLength: 5
     MaxLength: 20
-    NoEcho: true
     Default: 'johnsmith'
   DirectoryNewUserPassword:
     Description: New AD User Password

--- a/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
+++ b/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'This template deploys the full stack for Transfer Server including Transfer Server, custom IdP, Microsoft AD, VPC and Subnets'
+Description: 'This template deploys the full stack of the solution including Transfer Server stack, custom IdP stack, Microsoft AD Stack and new User Creation Stack'
 Parameters:
   DirectoryDNSName:
     Description: Microsoft ActiveDirectory DNS Name

--- a/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
+++ b/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
@@ -11,13 +11,23 @@ Parameters:
     MinLength: 5
     MaxLength: 20
     NoEcho: true
+  DirectoryNewUsername:
+    Description: New AD Username
+    Type: String
+    MinLength: 5
+    MaxLength: 20
+    NoEcho: true
+    Default: 'johnsmith'
   DirectoryBIOSName:
     Description: Microsoft ActiveDirectory BIOS Name
     Type: String
     Default: corp
     MinLength: 3
     MaxLength: 20
-
+  DirectorySearchBase:
+    Description: Active Directory Search Base e.g. OU=Users,OU=corp,DC=corp,DC=demoftp,DC=com
+    Type: String
+    Default: "OU=Users,OU=corp,DC=corp,DC=demoftp,DC=com"
   SecretsManagerPermissions:
     Description: Grant Lambda execution role permission to read Secrets Manager secrets (required to use the secrets_manager module)
     Type: String
@@ -25,7 +35,6 @@ Parameters:
     AllowedValues:
       - 'true'
       - 'false'
-
   UserNameDelimiter:
     Description: Delimiter for user name
     Type: String
@@ -108,6 +117,22 @@ Resources:
         Parameters:
           AuthorizationFunctionArn: !GetAtt CustomIdP.Outputs.IdpHandlerFunction
           BucketName: !Sub ${AWS::StackName}
+  AddADUser:
+      Type: 'AWS::CloudFormation::Stack'
+      DeletionPolicy: Delete
+      Properties:
+        TemplateURL: ./create_ad_user.yaml
+        Parameters:
+          IdpHandlerLayerArn: !GetAtt CustomIdP.Outputs.IdpHandlerLayer
+          SecurityGroupsList: !GetAtt CustomIdP.Outputs.SecurityGroupsList
+          SubnetList: !GetAtt CustomIdP.Outputs.SubnetList
+          ADServerDNS: !GetAtt ManagedAD.Outputs.PrimaryDNS
+          ADServerPort: 389
+          ADDomainUser: 'Admin'
+          ADDomainUserPassword: !Ref DirectoryAdminPassword
+          ADSearchBase: !Ref DirectorySearchBase
+          ADSSL: 'false'
+          NewADUser: !Ref DirectoryNewUsername
 Outputs:
   DirectoryID:
     Description: ID of the MS Directory

--- a/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
+++ b/solutions/custom-idp/examples/activedirectory/one-click-template.yaml
@@ -18,6 +18,13 @@ Parameters:
     MaxLength: 20
     NoEcho: true
     Default: 'johnsmith'
+  DirectoryNewUserPassword:
+    Description: New AD User Password
+    Type: String
+    MinLength: 5
+    MaxLength: 20
+    NoEcho: true
+
   DirectoryBIOSName:
     Description: Microsoft ActiveDirectory BIOS Name
     Type: String
@@ -133,6 +140,8 @@ Resources:
           ADSearchBase: !Ref DirectorySearchBase
           ADSSL: 'false'
           NewADUser: !Ref DirectoryNewUsername
+          NewADUserPassword: !Ref DirectoryNewUserPassword
+          DirectoryId: !GetAtt ManagedAD.Outputs.DirectoryID
 Outputs:
   DirectoryID:
     Description: ID of the MS Directory

--- a/solutions/custom-idp/examples/activedirectory/src/add_aduser_handler/app.py
+++ b/solutions/custom-idp/examples/activedirectory/src/add_aduser_handler/app.py
@@ -1,0 +1,143 @@
+import os
+import ssl
+import ldap3
+import boto3
+import logging
+import urllib3
+import json
+
+
+class LdapIdpModuleError(Exception):
+    """Used to raise module-specific exceptions"""
+    pass
+
+
+client_secrets = boto3.client('secretsmanager', region_name=os.environ["Region"])
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def lambda_handler(event, context):
+    try:
+        logger.debug(json.dumps(event))
+
+        if event['RequestType'] == 'Create':
+
+            ldap_host = os.environ["ADServerDNS"]
+            ldap_port = os.environ["ADServerPort"]
+            ldap_ssl = os.environ["ADSSL"]=='true'
+            ldap_search_base = os.environ["ADSearchBase"]
+            domain_username = get_secret(os.environ["ADDomainUser"])
+            domain_user_password =  get_secret(os.environ["ADDomainUserPassword"])
+            new_username = get_secret(os.environ["ADNewUser"])
+            ldap_ssl_verify = True
+            new_user_cn = f"cn={new_username},{ldap_search_base}"
+
+
+            ldap_tls = ldap3.Tls(
+                validate=ssl.CERT_NONE if not ldap_ssl_verify else ssl.CERT_REQUIRED
+            )
+
+            ldap_server = ldap3.Server(
+                host=ldap_host, port=int(ldap_port), use_ssl=ldap_ssl, tls=ldap_tls
+            )
+
+            ldap_connection = ldap3.Connection(
+                server=ldap_server,
+                user=domain_username,
+                password=domain_user_password, 
+                auto_bind=True,
+            )
+
+            bound = ldap_connection.bind()
+            if not bound:
+                raise LdapIdpModuleError(
+                    f"Unable to perform LDAP bind with credentials provided. Failing auth. Last error: {ldap_connection.last_error}"
+                )
+
+            attributes = get_attributes(new_username, "transfer", "testuser")
+
+            OBJECT_CLASS = ['top', 'person', 'organizationalPerson', 'user']
+            ldap_connection.add(new_user_cn, object_class=OBJECT_CLASS, attributes=attributes)
+            if ldap_connection.result["result"] != 0:
+                raise LdapIdpModuleError(
+                    f"Unable to create user. Last error: {ldap_connection.result['description']}"
+                )
+
+            ldap_connection.modify(new_user_cn, {'userAccountControl': [('MODIFY_REPLACE', 544)]})
+            if ldap_connection.result["result"] != 0:
+                raise LdapIdpModuleError(
+                    f"Unable to create user. Last error: {ldap_connection.result['description']}"
+                )
+
+            ldap_connection.unbind()
+            logger.debug(ldap_connection.result)
+
+            send_response(event, context, "SUCCESS", {"message":f"User {new_user_cn} created successfully."})
+            return 
+        
+        send_response(event, context, "SUCCESS", {"message":f"Request processed"})
+        return 
+
+    except Exception as e:
+        logger.error(f"add user failure: {str(e)}")
+        send_response(event, context, "FAILED", {"message": f"User creation failed. {str(e)}" })
+
+
+def get_secret(secret_name):
+    try:
+        logger.debug(f"getting secret {secret_name}")
+        get_secret_value_response = client_secrets.get_secret_value(SecretId=secret_name)
+        logging.info("Secret retrieved successfully.")
+        SecretString=get_secret_value_response["SecretString"]
+        logger.debug(f"value {SecretString}")
+        return SecretString
+    except client_secrets.exceptions.ResourceNotFoundException:
+        msg = f"The requested secret {secret_name} was not found."
+        logger.info(msg)
+        return msg
+    except Exception as e:
+        logger.error(f"An unknown error occurred: {str(e)}.")
+        raise
+
+def get_attributes(username, forename, surname):
+    return {
+        "displayName": username,
+        "sAMAccountName": username,
+        "userPrincipalName": "{0}@test.core.bogus.org.uk".format(username),
+        "name": username,
+        "givenName": forename,
+        "sn": surname
+    }
+
+
+def send_response(event, context, response_status, response_data, physical_resource_id=None, no_echo=False):
+
+    http = urllib3.PoolManager()
+    response_url = event['ResponseURL']
+
+    response_body = {}
+    response_body['Status'] = response_status
+    response_body['Reason'] = 'See the details in CloudWatch Log Stream: ' + context.log_stream_name
+    response_body['PhysicalResourceId'] = physical_resource_id or context.log_stream_name
+    response_body['StackId'] = event['StackId']
+    response_body['RequestId'] = event['RequestId']
+    response_body['LogicalResourceId'] = event['LogicalResourceId']
+    response_body['NoEcho'] = no_echo
+    response_body['Data'] = response_data
+
+    json_response_body = json.dumps(response_body)
+
+    headers = {
+        'content-type' : '',
+        'content-length' : str(len(json_response_body))
+    }
+
+    logger.info("AMI Lookup  Event Lambda handler sending response request " + json.dumps(json_response_body))
+    try:
+        response = http.request("PUT", response_url,
+                                body=json_response_body,
+                                headers=headers)
+        logger.info(f"AMI Lookup handler status: {response.status}")
+    except Exception as e:
+        logger.error("send_response(..) failed executing http.request(..): " + str(e))

--- a/solutions/custom-idp/examples/transferserver/transfer-server-template.yaml
+++ b/solutions/custom-idp/examples/transferserver/transfer-server-template.yaml
@@ -17,6 +17,7 @@ Resources:
       IdentityProviderType: AWS_LAMBDA
       IdentityProviderDetails:
         Function: !Ref AuthorizationFunctionArn
+      LoggingRole: !GetAtt CloudWatchLoggingRole.Arn
       Tags:
         - Key: Application
           Value: !Sub ${AWS::StackName}
@@ -88,7 +89,32 @@ Resources:
                   - s3:DeleteObject
                   - s3:DeleteObjectVersion
                 Resource: !Sub "${SFTPServerS3Bucket.Arn}/*"
-
+  CloudWatchLoggingRole:
+    Description: IAM role used by Transfer to log API requests to CloudWatch
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - transfer.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: TransferLogsPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:DescribeLogStreams
+                  - logs:PutLogEvents
+                Resource:
+                  Fn::Sub: '*'
 Outputs:
   TransferServerID:
     Description: Transfer Server ID


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
- Add new user automatically to the Microsoft AD as part of the deployment for the OneClick sample solution. This is accomplished by using a lambda custom resource to kick off the Add AD user process.
- updated template description

