### PR TITLE
Enhancements: Retrieve PublicKeys from LDAP attribute; Support for disabling identity providers

### DIFF
--- a/solutions/custom-idp/Pipfile
+++ b/solutions/custom-idp/Pipfile
@@ -15,4 +15,4 @@ aws-lambda-powertools = {extras = ["tracer"], version = "*"}
 [dev-packages]
 
 [requires]
-python_version = "3.11"
+python_version = "3.13"

--- a/solutions/custom-idp/Pipfile
+++ b/solutions/custom-idp/Pipfile
@@ -15,4 +15,4 @@ aws-lambda-powertools = {extras = ["tracer"], version = "*"}
 [dev-packages]
 
 [requires]
-python_version = "3.13"
+python_version = "3.11"

--- a/solutions/custom-idp/src/idp_handler/idp_modules/ldap.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/ldap.py
@@ -311,6 +311,19 @@ def handle_auth(
             raise LdapIdpModuleError(
                 f"LDAP attribute {ldap_attributes['Policy']} for property 'Policy' was empty or missing. Enable debug logging adn check LDAP response. To ignore, use the ignore_missing_attributes setting in the identity provider config."
             )
+        
+    if "PublicKeys" in ldap_attributes:
+        if not ldap_resolved_attributes["PublicKeys"] is None:
+            logger.info("Applying PublicKeys from LDAP Attributes")
+            response_data["PublicKeys"] = json.loads(ldap_resolved_attributes["PublicKeys"])
+        elif ldap_ignore_missing_attributes:
+            logger.warning(
+                f"LDAP attribute {ldap_attributes['PublicKeys']} for 'PublicKeys' was empty of missing. Skipping."
+            )
+        else:
+            raise LdapIdpModuleError(
+                f"LDAP attribute {ldap_attributes['PublicKeys']} for property 'PublicKeys' was empty or missing. Enable debug logging adn check LDAP response. To ignore, use the ignore_missing_attributes setting in the identity provider config."
+            )        
 
     if "Uid" in ldap_attributes and "Gid" in ldap_attributes:
         if (


### PR DESCRIPTION
*Issue #, if available:*
#46 

#48 

*Description of changes:*

- SSH public keys stored in LDAP attributes can now be retrieved and mapped to the `PublicKeys` field.
- Identity providers can now be disabled by setting `disabled` to `True` in the `identitiy_provider` record.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
