### PR TITLE
Boto3 settings

### DIFF
--- a/solutions/custom-idp/README.md
+++ b/solutions/custom-idp/README.md
@@ -2409,7 +2409,7 @@ Follow these same steps to return the **LogLevel** setting to `INFO` after finis
 
   Repeat the same steps for `sts.[REGION].amazonaws.com` and `secretsmanager.[REGOIN].amazonaws.com`. 
 
-  If these requests are successful, use the EC2 instance to verify the configured identity provider is reachable.
+  If these requests are successful, use the EC2 instance to verify the configured identity provider is reachable. 
 
 # FAQ
 * **Can I connect and use multiple identity providers using the same custom IdP deployment?**

--- a/solutions/custom-idp/README.md
+++ b/solutions/custom-idp/README.md
@@ -155,7 +155,9 @@ The AWS Transfer Family Custom IdP Solution is deployed using a Serverless Appli
 
 ## Prerequisites
 Before deploying the solution, you will need the following: 
-* A Virtual Private Cloud (VPC) with private subnets with either internet connectivity via NAT Gateway, or a DynamoDB Gateway Endpoint. 
+* A Virtual Private Cloud (VPC) with private subnets with either:
+  * Internet connectivity via NAT Gateway
+  * VPC endpoints for DynamoDB, Security Token Service (STS), and Secrets Manager.
 * Appropriate IAM permissions to deploy the `custom-idp.yaml` CloudFormation template, including but not limited to creating CodePipeline and CodeBuild projects, IAM roles, and IAM policies.
 
 > [!IMPORTANT]  
@@ -192,7 +194,7 @@ Before deploying the solution, you will need the following:
     | **CreateVPC** | **REQUIRED**. Set to *`true`* if you you would like the solution to create a VPC for you, otherwise *`false`* | `true` or `false`|
     | **VPCCIDR** | **CONDITIONALLY REQUIRED**. Must be set if `CreateVPC` is `true`. The CIDR to use for when creating a new VPC. The CIDR should be at least a /24 and will be divided evenly across 4 subnets. Required if CreateVPC is set.  | `true` or `false`|   
     | **VPCId** | **CONDITIONALLY REQUIRED**. Must be set if `CreateVPC` is `false`. The ID of the VPC to deploy the custom IDP solution into. The VPC specified should have network connectivity to any IdPs that will used for authentication.  | *A VPC ID, i.e. `vpc-abc123def456`* |    
-    | **Subnets** | **CONDITIONALLY REQUIRED**. Must be set if `CreateVPC` is `false`. A list of subnet IDs to attach the Lambda function to. The Lambda is attached to subnets in order to allow private communication to IdPs such as LDAP servers or Active Directory domain controllers. At least one subnet must be specified, and all subnets must be in the same VPC specified above. **IMPORTANT**: The subnets must be able to reach DynamoDB service endpoints. If using public IdP such as Okta, the subnet must also have a route to a NAT Gateway that can forward requests to the internet. *Using a public subnet will not work because Lambda network interfaces are not assigned public IP addresses*.  | *comma-separated list of subnet IDs, i.e. `subnet-123abc,subnet-456def`* |
+    | **Subnets** | **CONDITIONALLY REQUIRED**. Must be set if `CreateVPC` is `false`. A list of subnet IDs to attach the Lambda function to. The Lambda is attached to subnets in order to allow private communication to IdPs such as LDAP servers or Active Directory domain controllers. At least one subnet must be specified, and all subnets must be in the same VPC specified above. **IMPORTANT**: The subnets must be able to reach DynamoDB, STS, and Secrets Manager service endpoints. If using public IdP such as Okta, the subnet must also have a route to a NAT Gateway that can forward requests to the internet. *Using a public subnet will not work because Lambda network interfaces are not assigned public IP addresses*.  | *comma-separated list of subnet IDs, i.e. `subnet-123abc,subnet-456def`* |
     | **SecurityGroups** | **CONDITIONALLY REQUIRED**. Must be set if `CreateVPC` is false. A list of security group IDs to assign to the Lambda function. This is used to control inbound and outbound access to/from the ENI the Lambda function uses for network connectivity. At least one security group must be specified and the security group must belong to the VPC specified above. | *comma-separated list of Security Group IDs, i.e. `sg-abc123`* |
     | **UserNameDelimiter**  | The delimiter to use when specifying both the username and IdP name during login. It is recommended that `@@` be used to avoid issues with parsing email addresses, e.g. `[username]@@[IdP-name]`. Currently, only the `@` character is supported due to validation checks that AWS Transfer Family performs on the username.  | **`@@`** |    
     | **SecretsManagerPermissions** | Set to *`true`* if you will use the Secrets Manager authentication module, otherwise *`false`* | `true` or `false`|
@@ -2361,7 +2363,7 @@ Follow these same steps to return the **LogLevel** setting to `INFO` after finis
 
 * **After deploying the solution, authentication requests fail and/or the Lambda function logs show timeouts.**
 
-  Verify the custom IdP solution has been configured to use subnets in a VPC that can reach DynamoDB and IdP targets. Also verify the selected security groups have outbound rules that permit traffic to reach these targets. One way to verify this is to launch an EC2 instance WITHOUT a public IP address in the subnets and attempt to reach the targets. For example, using curl to send a request to the DynamoDB regional endpoint should return an HTTP status code like the one below and not timeout: 
+  Verify the custom IdP solution has been configured to use subnets in a VPC that can reach DynamoDB, Security Token Service (STS) and Secrets Manager service endpoints. The funciton must also be able to reach any IdP target endpoints, such as Okta public endpoints or LDAP servers (depending on IdP configuration). Also verify the selected security groups have outbound rules that permit traffic to reach these targets. One way to verify this is to launch an EC2 instance WITHOUT a public IP address in the subnets and attempt to reach the targets. For example, using curl to send a request to the DynamoDB regional endpoint should return an HTTP status code like the one below and not timeout: 
   
   ```
   ➜  ~ curl https://dynamodb.[REGION].amazonaws.com -v
@@ -2404,6 +2406,10 @@ Follow these same steps to return the **LogLevel** setting to `INFO` after finis
   * Connection #0 to host dynamodb.us-east-1.amazonaws.com left intact
   healthy: dynamodb.us-east-1.amazonaws.com %
   ``` 
+
+  Repeat the same steps for `sts.[REGION].amazonaws.com` and `secretsmanager.[REGOIN].amazonaws.com`. 
+
+  If these requests are successful, use the EC2 instance to verify the configured identity provider is reachable.
 
 # FAQ
 * **Can I connect and use multiple identity providers using the same custom IdP deployment?**

--- a/solutions/custom-idp/src/idp_handler/app.py
+++ b/solutions/custom-idp/src/idp_handler/app.py
@@ -12,6 +12,7 @@ from aws_lambda_powertools import Tracer
 tracer = Tracer()
 
 import boto3
+import botocore
 from boto3.dynamodb.conditions import Key
 from idp_modules import util
 
@@ -19,16 +20,19 @@ from idp_modules import util
 logger = logging.getLogger(__name__)
 logger.setLevel(util.get_log_level())
 
-# dynamodb init
+
+os.environ["AWS_STS_REGIONAL_ENDPOINTS"] = "regional"
+
+AWS_REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
+
 USERS_TABLE_ID = os.environ["USERS_TABLE"]
 IDENTITY_PROVIDERS_TABLE_ID = os.environ["IDENTITY_PROVIDERS_TABLE"]
 USER_NAME_DELIMITER = os.environ["USER_NAME_DELIMITER"]
 
-USERS_TABLE = boto3.resource("dynamodb").Table(USERS_TABLE_ID)
-IDENTITY_PROVIDERS_TABLE = boto3.resource("dynamodb").Table(IDENTITY_PROVIDERS_TABLE_ID)
+ACCOUNT_ID = boto3.client('sts', config=util.boto3_config).get_caller_identity().get('Account')
+USERS_TABLE = boto3.resource("dynamodb", config=util.boto3_config).Table(USERS_TABLE_ID)
+IDENTITY_PROVIDERS_TABLE = boto3.resource("dynamodb",config=util.boto3_config).Table(IDENTITY_PROVIDERS_TABLE_ID)
 
-ACCOUNT_ID = boto3.client('sts').get_caller_identity().get('Account')
-AWS_REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", ""))
 
 class IdpHandlerException(Exception):
     """Used to raise handler exceptions"""

--- a/solutions/custom-idp/src/idp_handler/idp_modules/util.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/util.py
@@ -19,7 +19,7 @@ def get_log_level():
 logger = logging.getLogger(__name__)
 logger.setLevel(get_log_level())
 
-boto3_config = Config(retries={"max_attempts": 10, "mode": "standard"})
+boto3_config = Config(retries={"max_attempts": 5, "mode": "standard"}, connect_timeout=5)
 
 
 class IdpModuleError(Exception):
@@ -27,12 +27,9 @@ class IdpModuleError(Exception):
 
     pass
 
-
 class AuthenticationMethod(Enum):
     PASSWORD = 1
     PUBLIC_KEY = 2
-
-
 
 @tracer.capture_method
 def get_secret(secret_id):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Configured boto3 to use regional STS endpoints to resolve timeout errors when Lambda is attached to subnet without internet access and uses a VPC endpoint for STS
* Set retries to 3 and timeouts to 3 on boto3 clients so that clients timeout before the runtime does.
* Updated README to clarify PrivateLink endpoints required if the Lambda is in a private subnet (without NAT Gateway). Clarified troubleshooting steps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
