### PR TITLE
Fix if statement to handle PublickKeys attribute during password auth

### DIFF
--- a/solutions/custom-idp/src/idp_handler/idp_modules/ldap.py
+++ b/solutions/custom-idp/src/idp_handler/idp_modules/ldap.py
@@ -93,7 +93,7 @@ def handle_auth(
     ldap_attribute_query_list = []
 
     # If this is a password-based authentication flow, public keys must not be returned in the response to AWS Transfer Family, we it will be filtered out in the LDAP reques to avoid unnecessary retrieval.
-    if util.AuthenticationMethod.PASSWORD and "PublicKeys" in ldap_attributes: 
+    if authn_method == util.AuthenticationMethod.PASSWORD and "PublicKeys" in ldap_attributes: 
         ldap_attributes.pop("PublicKeys")
 
     for attribute in ldap_attributes:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* If the if statement that removes the PublicKeys attribute from LDAP attribute list if the authentication method is password-based. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
